### PR TITLE
removed markdown font-size increase for headers

### DIFF
--- a/styles/languages/markdown.less
+++ b/styles/languages/markdown.less
@@ -20,32 +20,26 @@ atom-text-editor, :host {
     .markup.heading.heading-1 {
       color:@px-text;
       font-weight:bold;
-      font-size : ~"calc(30px)";
     }
     .markup.heading.heading-2 {
       color:@px-text;
       font-weight:bold;
-      font-size : ~"calc(26px)";
     }
     .markup.heading.heading-3 {
       color:@px-text;
       font-weight:bold;
-      font-size : ~"calc(22px)";
     }
     .markup.heading.heading-4 {
       color:@px-text;
       font-weight:bold;
-      font-size : ~"calc(20px)";
     }
     .markup.heading.heading-5 {
       color:@px-text;
       font-weight:bold;
-      font-size : ~"calc(18px)";
     }
     .markup.heading.heading-6 {
       color:@px-text;
       font-weight:bold;
-      font-size : ~"calc(16px)";
     }
     .markup.heading.marker {
       color:@px-text;


### PR DESCRIPTION
Since headers font size increase breaks atom line height, let's remove them.  re: issue: https://github.com/promek/wombat-light-syntax/issues/2
